### PR TITLE
Remove 10 second rule

### DIFF
--- a/src/base/Generator.php
+++ b/src/base/Generator.php
@@ -73,20 +73,15 @@ abstract class Generator implements GeneratorInterface
     }
 
     /**
-     * Don't regenerate the file if it already exists, and is less than 10 seconds old
+     * Don't regenerate the file if it already exists
      *
      * @return bool
      */
     protected static function shouldRegenerateFile(): bool
     {
         $path = self::getGeneratedFilePath();
-        if (is_file($path)) {
-            if (time() - filemtime($path) < 10) {
-                return false;
-            }
-        }
 
-        return true;
+        return !is_file($path);
     }
 
     /**


### PR DESCRIPTION
@khalwat Craft generates the `CustomFieldBehavior` class only if the file already exists – the 10 second rule comes only later in the generation process.
https://github.com/craftcms/cms/blob/96fc9a3f2fc7caabc44d12d786dea2a39ffa4b62/src/Craft.php#L183-L186