### PR TITLE
Fix “Twig instantiated” error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.11.1 - 2023.07.03
+### Fixed
+* Fixed an issue in which the plugin was instantiating Twig before Craft was fully initialized.
+
 ## 1.11.0 - 2022.12.19
 ### Changed
 * Refactored how CraftVariable Behaviors are parsed to use PHP Reflection so we can get all methods & properties added via behavior to the CraftVariable. Allows `craft.orders()` to work, for example ([#10](https://github.com/nystudio107/craft-autocomplete/issues/10))
 
 ## 1.10.1 - 2022.08.23
 ### Changed
-* Add `allow-plugins` to `composer.json` so CI can work
+* Added `allow-plugins` to `composer.json` so CI can work
 
 ### Fixed
 * Fixed an issue where an exception could be thrown during the bootstrap process in earlier versions of Yii2 due to `$id` not being set

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nystudio107/craft-autocomplete",
   "description": "Provides Twig template IDE autocomplete of Craft CMS & plugin variables",
   "type": "yii2-extension",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "keywords": [
     "craft",
     "cms",

--- a/src/Autocomplete.php
+++ b/src/Autocomplete.php
@@ -128,7 +128,7 @@ class Autocomplete extends Module implements BootstrapInterface
         Event::on(Plugins::class, Plugins::EVENT_AFTER_INSTALL_PLUGIN, [$this, 'regenerateAutocompleteClasses']);
         Event::on(Plugins::class, Plugins::EVENT_AFTER_UNINSTALL_PLUGIN, [$this, 'deleteAutocompleteClasses']);
         Event::on(Globals::class, Globals::EVENT_AFTER_SAVE_GLOBAL_SET, [$this, 'deleteAutocompleteClasses']);
-        Event::on(Plugins::class, Plugins::EVENT_AFTER_LOAD_PLUGINS, [$this, 'generateAutocompleteClasses']);
+        Event::on(CraftWebApp::class, CraftWebApp::EVENT_INIT, [$this, 'generateAutocompleteClasses']);
         Craft::info('Event Handlers installed', __METHOD__);
     }
 


### PR DESCRIPTION
Fixes an issue in which the plugin was instantiating Twig before Craft was fully initialized, causing errors in logs and console commands.

<img width="1208" alt="Screenshot 2023-07-02 at 08 29 54" src="https://github.com/nystudio107/craft-autocomplete/assets/57572400/d63ef390-acd6-4f9f-82b6-d0aa22d0f58e">
